### PR TITLE
Fix add live promise problem

### DIFF
--- a/src/data/mutations/startLive.js
+++ b/src/data/mutations/startLive.js
@@ -8,22 +8,24 @@ const startLive = {
   args: {
     id: { type: GraphQLString },
   },
-  resolve(fieldName, { id }, context, { rootValue: request }) {
-    return new Promise((resolve, reject) => {
+  async resolve(fieldName, { id }, context, { rootValue: request }) {
+    const addLivePromise = new Promise((resolve, reject) => {
       if (!request.user) {
         resolve(false);
       }
 
       const redis = createClient(redisUrl);
       redis.rpush('live', id, (err, reply) => {
+        redis.quit();
         if (!err) {
           resolve(true);
         } else {
           reject(err);
         }
-        redis.quit();
       });
     });
+
+    return await addLivePromise;
   }
 };
 


### PR DESCRIPTION
When live started, GraphQL mutation always returns false even user was signed in.
It seems live resolver can't return plain promise object, thus, await the promise done.